### PR TITLE
Make game phrase method more robust

### DIFF
--- a/test/views/page_view_test.exs
+++ b/test/views/page_view_test.exs
@@ -1,3 +1,31 @@
 defmodule Nermesterts.PageViewTest do
   use Nermesterts.ConnCase, async: true
+
+  alias Nermesterts.PageView
+  alias Nermesterts.Phrase
+  alias Nermesterts.Game
+
+  @phrase_no_token %Phrase{message: "Name of the game", has_token: false}
+  @phrase_with_token %Phrase{message: "Name of the #GAME#", has_token: true}
+  @valid_game %Game{name: "bloopers"}
+
+  test "nil phrase with no game provided" do
+    assert PageView.selected_game_phrase(nil) == ""
+  end
+
+  test "existing phrase without token or game" do
+    assert PageView.selected_game_phrase(@phrase_no_token) == "Name of the game"
+  end
+
+  test "existing phrase with token and game" do
+    assert PageView.selected_game_phrase(@phrase_with_token, @valid_game) == "Name of the <h3>bloopers</h3>"
+  end
+
+  test "existing phrase with token and nil game" do
+    assert PageView.selected_game_phrase(@phrase_with_token, nil) == ""
+  end
+
+  test "existing phrase with no token but with game" do
+    assert PageView.selected_game_phrase(@phrase_no_token, @valid_game) == "Name of the game"
+  end
 end

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -1,7 +1,7 @@
 <div class="jumbotron">
   <h2><%= gettext "Welcome to %{name}", name: "NermeSterts!" %></h2>
   <%# I'd like to find a better way to do this. I'd like to escape the game name, then wrap it in h3 %>
-  <%= raw(String.replace(@phrase.message, "#GAME#", name_of_the(@game))) %>
+  <%= raw(selected_game_phrase(@phrase, @game)) %>
 </div>
 <div>
   <%= render Nermesterts.PlayerView, "index.html", players: @players, conn: @conn %>

--- a/web/views/page_view.ex
+++ b/web/views/page_view.ex
@@ -1,10 +1,19 @@
 defmodule Nermesterts.PageView do
   use Nermesterts.Web, :view
 
-  def name_of_the(game) do
-    case game do
-      %{name: name} -> "<h3>" <> name <> "</h3>"
-      _ -> ""
-    end
+  alias Nermesterts.Phrase
+  alias Nermesterts.Game
+
+  def selected_game_phrase(%Phrase{message: message, has_token: true}, %Game{name: name}) do
+    String.replace(message, "#GAME#", "<h3>" <> name <> "</h3>")
   end
+  def selected_game_phrase(%Phrase{message: _, has_token: true}, _) do
+    ""
+  end
+  def selected_game_phrase(phrase, _) do
+    selected_game_phrase(phrase)
+  end
+
+  def selected_game_phrase(%Phrase{message: message, has_token: false}), do: message
+  def selected_game_phrase(_), do: ""
 end


### PR DESCRIPTION
Worked with @ericworkman on this (cc: @daveshah). Currently if there are no phrases in the database, the server returns a 500. This PR makes the game phrase feature more robust and covers situations where either the phrase or the game is missing.