### PR TITLE
Fix for npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "devDependencies": {
     "babel-brunch": "~6.0.0",
+    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-es2016": "^6.16.0",
     "brunch": "2.7.4",
     "clean-css-brunch": "~2.0.0",
     "css-brunch": "~2.0.0",


### PR DESCRIPTION
Running `npm run build` was failing, causing a missing app.js file. It looks like these two dependencies were missing.